### PR TITLE
Prepare for next iteration (0.4.3).

### DIFF
--- a/com.asakusafw.shafu.releng/build.gradle
+++ b/com.asakusafw.shafu.releng/build.gradle
@@ -24,7 +24,7 @@ def targetFeatures = [
     'com.asakusafw.shafu.feature',
     'com.asakusafw.shafu.asakusafw.feature',
 ]
-def targetVersion = '0.4.2.qualifier'
+def qualifier = System.getProperty('qualifier', "N${new Date().format('yyyyMMddHHmmss')}")
 def targetDropinName = 'jinrikisha'
 
 def eclipseUrl = System.getProperty('eclipse.download', 'http://archive.eclipse.org/eclipse/downloads/drops/R-3.7.2-201202080800/eclipse-SDK-3.7.2-win32.zip')
@@ -120,7 +120,8 @@ task pdeBuild(dependsOn: [prepareTools, copySources]) {
                         '-DtopLevelElementId=' + targetFeature,
                         '-DbuildLabel=' + productionDirectory.name,
                         '-DbuildId=prod',
-                        '-DtargetVersion=' + targetVersion,
+                        "-DtargetVersion=${baseVersion}.qualifier",
+                        "-DforceContextQualifier=${qualifier}",
                         '-DbuildDirectory=' + copySources.pdeBuildDirectory.absolutePath,
                         '-DbaseLocation=' + prepareTools.eclipseDirectory.absolutePath,
                         '-DarchivePrefix=eclipse',

--- a/com.asakusafw.shafu.releng/gradle.properties
+++ b/com.asakusafw.shafu.releng/gradle.properties
@@ -1,0 +1,1 @@
+baseVersion=0.4.3


### PR DESCRIPTION
You can specify each feature/plug-in version as following:
1. Put the base version in `com.asakusafw.shafu.releng/gradle.properties`.
2. Run `gradlew` with `-Dqualifier=<qualifier>`.
   
   The qualifier must be in the form of `[0-9A-Za-z_-]+`. Without qualifier, we use `N<date>` implicitly, and thus explicit qualifier which is newer than the other implicit versions should be greater than `N` in lexicographic order (e.g. `RC1`, `RELEASE`, ...).
