### PR TITLE
Gradle task names now accepts `@<Gradle-version>`.

### DIFF
--- a/com.asakusafw.shafu.core/src/com/asakusafw/shafu/core/util/CommandLineUtil.java
+++ b/com.asakusafw.shafu.core/src/com/asakusafw/shafu/core/util/CommandLineUtil.java
@@ -22,12 +22,15 @@ import java.util.List;
 /**
  * Utilities for command lines.
  * @since 0.2.4
+ * @version 0.4.3
  */
 public final class CommandLineUtil {
 
     private static final char ESCAPE = '\\';
 
     private static final char SEPARATOR_CHAR = '#';
+
+    private static final char VERSION_CHAR = '@';
 
     private static final String SEPARATOR = String.valueOf(SEPARATOR_CHAR);
 
@@ -37,7 +40,7 @@ public final class CommandLineUtil {
      * @return the parsed tokens
      */
     public static List<String> parseGradleTaskNames(String commandLine) {
-        List<String> tokens = parseCommandLineTokens(commandLine);
+        List<String> tokens = removeGradleVersion(parseCommandLineTokens(commandLine));
         int separatorAt = findSeparator(tokens);
         if (separatorAt < 0) {
             return tokens;
@@ -52,13 +55,42 @@ public final class CommandLineUtil {
      * @return the parsed tokens
      */
     public static List<String> parseGradleBuildArguments(String commandLine) {
-        List<String> tokens = parseCommandLineTokens(commandLine);
+        List<String> tokens = removeGradleVersion(parseCommandLineTokens(commandLine));
         int separatorAt = findSeparator(tokens);
         if (separatorAt < 0) {
             return Collections.emptyList();
         } else {
             return tokens.subList(separatorAt + 1, tokens.size());
         }
+    }
+
+    /**
+     * Extracts and returns the instant Gradle version from the command line string.
+     * @param commandLine the command line string
+     * @return the parsed version, or {@code null} if it is not found
+     * @since 0.4.3
+     */
+    public static String parseGradleVersion(String commandLine) {
+        List<String> tokens = parseCommandLineTokens(commandLine);
+        if (tokens.isEmpty()) {
+            return null;
+        }
+        String first = tokens.get(0);
+        return extractGradleVersion(first);
+    }
+
+    private static List<String> removeGradleVersion(List<String> tokens) {
+        if (tokens.isEmpty() || extractGradleVersion(tokens.get(0)) == null) {
+            return tokens;
+        }
+        return new ArrayList<String>(tokens.subList(1, tokens.size()));
+    }
+
+    private static String extractGradleVersion(String first) {
+        if (first.length() >= 2 && first.charAt(0) == VERSION_CHAR) {
+            return first.substring(1);
+        }
+        return null;
     }
 
     /**

--- a/com.asakusafw.shafu.ui/src/com/asakusafw/shafu/internal/ui/handlers/BuildProjectHandler.java
+++ b/com.asakusafw.shafu.ui/src/com/asakusafw/shafu/internal/ui/handlers/BuildProjectHandler.java
@@ -15,6 +15,7 @@
  */
 package com.asakusafw.shafu.internal.ui.handlers;
 
+import java.net.URI;
 import java.text.MessageFormat;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -29,6 +30,7 @@ import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.handlers.HandlerUtil;
 
+import com.asakusafw.shafu.core.gradle.GradleContext;
 import com.asakusafw.shafu.core.util.CommandLineUtil;
 import com.asakusafw.shafu.internal.ui.Activator;
 import com.asakusafw.shafu.internal.ui.LogUtil;
@@ -65,9 +67,20 @@ public class BuildProjectHandler extends AbstractHandler {
         if (PlatformUI.getWorkbench().saveAllEditors(true) == false) {
             return null;
         }
-        List<String> tasks = CommandLineUtil.parseGradleTaskNames(commandLine);
         List<String> arguments = CommandLineUtil.parseGradleBuildArguments(commandLine);
-        ShafuUi.scheduleTasks(project, tasks, arguments);
+        GradleContext context = ShafuUi.createContext(project, arguments);
+        String gradleVersion = CommandLineUtil.parseGradleVersion(commandLine);
+        if (gradleVersion != null) {
+            // like URL
+            if (gradleVersion.indexOf(':') >= 0) {
+                context.setGradleDistribution(URI.create(gradleVersion));
+            } else {
+                context.setGradleDistribution(null);
+                context.setGradleVersion(gradleVersion);
+            }
+        }
+        List<String> tasks = CommandLineUtil.parseGradleTaskNames(commandLine);
+        ShafuUi.scheduleTasks(project, context, tasks);
         return null;
     }
 

--- a/com.asakusafw.shafu.ui/src/com/asakusafw/shafu/ui/ShafuUi.java
+++ b/com.asakusafw.shafu.ui/src/com/asakusafw/shafu/ui/ShafuUi.java
@@ -47,7 +47,8 @@ import com.asakusafw.shafu.ui.consoles.ShafuConsole;
 
 /**
  * Core APIs of Shafu UI Plug-in.
- * @version 0.2.4
+ * @since 0.1.0
+ * @version 0.4.3
  */
 public final class ShafuUi {
 
@@ -73,6 +74,17 @@ public final class ShafuUi {
      */
     public static void scheduleTasks(IProject project, List<String> tasks, List<String> arguments) {
         GradleContext configuration = ShafuUi.createContext(project, project.getLocation().toFile(), arguments);
+        scheduleTasks(project, configuration, tasks);
+    }
+
+    /**
+     * Schedules the Gradle tasks.
+     * @param project the target project
+     * @param configuration the Gradle configuration
+     * @param tasks the target tasks
+     * @since 0.4.3
+     */
+    public static void scheduleTasks(IProject project, GradleContext configuration, List<String> tasks) {
         ShafuConsole console = ShafuUi.getGlobalConsole(true);
         console.clearConsole();
         console.attachTo(configuration);
@@ -93,6 +105,19 @@ public final class ShafuUi {
      */
     public static GradleContext createContext(File projectDirectory) {
         return createContext(null, projectDirectory, Collections.<String>emptyList());
+    }
+
+    /**
+     * Creates a new {@link GradleContext} configured by Shafu UI.
+     * @param project the target project
+     * @param arguments the build arguments
+     * @return the created {@link GradleContext}
+     * @see GradleBuildTask
+     * @see GradleInspectTask
+     * @since 0.4.3
+     */
+    public static GradleContext createContext(IProject project, List<String> arguments) {
+        return createContext(project, project.getLocation().toFile(), Collections.<String>emptyList());
     }
 
     private static GradleContext createContext(IProject project, File projectDirectory, List<String> arguments) {


### PR DESCRIPTION
This enables to select a temporary Gradle version from 'Build with Task Names...' in context menu (e.g. `@1.12 clean build`). The version specifier must be on the head of the command line.
