### PR TITLE
Change distribution location to https.

### DIFF
--- a/com.asakusafw.shafu.ui/src/com/asakusafw/shafu/internal/ui/preferences/ShafuPreferenceConstants.java
+++ b/com.asakusafw.shafu.ui/src/com/asakusafw/shafu/internal/ui/preferences/ShafuPreferenceConstants.java
@@ -126,9 +126,13 @@ public final class ShafuPreferenceConstants {
 
     /**
      * The default value of {@link #KEY_USE_HTTPS}.
+     *
+     * NOTE: Shafu changed the default value since 0.5.1 -
+     * Insecure location returns 301, but Gradle tooling API does not follow to the moved location.
+     *
      * @since 0.3.1
      */
-    public static final boolean DEFAULT_USE_HTTPS = false;
+    public static final boolean DEFAULT_USE_HTTPS = true;
 
     /**
      * The Gradle distribution default value.

--- a/com.asakusafw.shafu.ui/src/com/asakusafw/shafu/ui/ShafuUi.java
+++ b/com.asakusafw.shafu.ui/src/com/asakusafw/shafu/ui/ShafuUi.java
@@ -133,6 +133,7 @@ public final class ShafuUi {
         File javaHome = computeJavaHome(project, prefs);
         String gradleVersion = decodeVersion(prefs.getString(KEY_GRADLE_VERSION));
         URI gradleDistribution = decodeUri(prefs.getString(KEY_GRADLE_DISTRIBUTION));
+        boolean useHttps = prefs.getBoolean(KEY_USE_HTTPS);
 
         if (appearsIn(GradleLogLevel.values(), arguments) == false) {
             context.withGradleArguments(logLevel.getArguments());
@@ -156,6 +157,7 @@ public final class ShafuUi {
         context.setJavaHomeDir(javaHome);
         context.setGradleVersion(gradleVersion);
         context.setGradleDistribution(gradleDistribution);
+        context.setUseHttps(useHttps);
 
         return context;
     }


### PR DESCRIPTION
## Summary

This PR changes the Gradle distribution locations {`https` => `http`}.

## Background, Problem or Goal of the patch

It seems that `http://services.gradle.org/distributions` returns HTTP 301 (Moved Permanently) and it relocated to `https://...`. In such a case, Gradle tooling API obtains empty distributions.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.
