### PR TITLE
Shafu console disables scroll lock on starting builds.

### DIFF
--- a/com.asakusafw.shafu.ui/src/com/asakusafw/shafu/ui/ShafuUi.java
+++ b/com.asakusafw.shafu.ui/src/com/asakusafw/shafu/ui/ShafuUi.java
@@ -86,7 +86,7 @@ public final class ShafuUi {
      */
     public static void scheduleTasks(IProject project, GradleContext configuration, List<String> tasks) {
         ShafuConsole console = ShafuUi.getGlobalConsole(true);
-        console.clearConsole();
+        console.reset();
         console.attachTo(configuration);
 
         new RunnableBuilder(Messages.ShafuUi_buildJobName)


### PR DESCRIPTION
## Summary

This PR disables console scroll lock on every starting build.

## Background, Problem or Goal of the patch

Shafu sometimes  turns console scroll lock on when clearing its contents.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.