### PR TITLE
Remove 'enable emulation mode' settings.

### DIFF
--- a/com.asakusafw.shafu.asakusafw/scripts/init.gradle
+++ b/com.asakusafw.shafu.asakusafw/scripts/init.gradle
@@ -60,47 +60,6 @@ allprojects { Project project ->
         }
     }
 
-    // enables emulation mode in testing
-    withAsakusa {
-        def key = 'com.asakusafw.shafu.asakusafw.enableEmulationMode'
-        def value = System.getProperty(key, 'false')
-        if (value == null || value.equalsIgnoreCase('true') == false) {
-            return
-        }
-        project.afterEvaluate {
-            logger.info "enabling emulation mode for Asakusa Framework: ${project.name}"
-            String version
-            try {
-                version = project.asakusafw.asakusafwVersion.toString()
-            } catch (Exception e) {
-                logger.info "failed to resolve asakusafwVersion: ${project.name}", e
-                return
-            }
-            project.configurations {
-                shafuEmulationModeExtension
-            }
-            project.dependencies {
-                shafuEmulationModeExtension "com.asakusafw.sdk:asakusa-sdk-test-emulation:${version}"
-            }
-            logger.info "try resolving modules for emulation mode: ${project.name}"
-            Configuration conf = project.configurations.shafuEmulationModeExtension
-            try {
-                conf.resolve()
-                if (conf.state != Configuration.State.RESOLVED) {
-                    throw new IllegalStateException()
-                }
-            } catch (Exception e) {
-                logger.info "emulation support module is not provided (${version}): ${project.name}"
-                logger.debug "state of ${conf.name}: ${conf.state}", e
-                return
-            }
-            logger.info "activating modules for emulation mode: ${project.name}"
-            project.configurations.testRuntime {
-                extendsFrom project.configurations.shafuEmulationModeExtension
-            }
-        }
-    }
-
     // adding a task for installing batchapps
     withAsakusa {
         project.afterEvaluate {

--- a/com.asakusafw.shafu.asakusafw/src/com/asakusafw/shafu/internal/asakusafw/gradle/AsakusaFrameworkGradleContextEnhancer.java
+++ b/com.asakusafw.shafu.asakusafw/src/com/asakusafw/shafu/internal/asakusafw/gradle/AsakusaFrameworkGradleContextEnhancer.java
@@ -21,28 +21,22 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
-import org.eclipse.jface.preference.IPreferenceStore;
 import org.osgi.framework.Bundle;
 
 import com.asakusafw.shafu.core.gradle.GradleContext;
 import com.asakusafw.shafu.core.gradle.IGradleContextEnhancer;
 import com.asakusafw.shafu.core.util.StatusUtils;
 import com.asakusafw.shafu.internal.asakusafw.Activator;
-import com.asakusafw.shafu.internal.asakusafw.preferences.ShafuAsakusaPreferenceConstants;
 
 /**
  * Enhances {@link GradleContext} for Asakusa Framework.
- * @since 0.2.10
+ * @since 0.5.3
  */
 public class AsakusaFrameworkGradleContextEnhancer implements IGradleContextEnhancer {
 
     private static final IPath SCRIPT_BASE_PATH = Path.fromPortableString("scripts"); //$NON-NLS-1$
 
     private static final IPath SCRIPT_PATH = SCRIPT_BASE_PATH.append("init.gradle"); //$NON-NLS-1$
-
-    private static final String PREFIX_KEY = Activator.PLUGIN_ID + "."; //$NON-NLS-1$
-
-    private static final String KEY_EMULATION_MODE = PREFIX_KEY + "enableEmulationMode"; //$NON-NLS-1$
 
     @Override
     public void enhance(IProgressMonitor monitor, GradleContext context) throws CoreException {
@@ -58,7 +52,6 @@ public class AsakusaFrameworkGradleContextEnhancer implements IGradleContextEnha
     private void configureContext(SubMonitor monitor, GradleContext context, File script) throws CoreException {
         StatusUtils.checkCanceled(monitor);
         configureGradleArguments(context, script);
-        configureExtensionSettings(context);
     }
 
     private void configureGradleArguments(GradleContext context, File script) {
@@ -67,13 +60,6 @@ public class AsakusaFrameworkGradleContextEnhancer implements IGradleContextEnha
         newArguments.add(script.getAbsolutePath());
         newArguments.addAll(context.getGradleArguments());
         context.setGradleArguments(newArguments);
-    }
-
-    private void configureExtensionSettings(GradleContext context) {
-        IPreferenceStore prefs = Activator.getDefault().getPreferenceStore();
-        if (prefs.getBoolean(ShafuAsakusaPreferenceConstants.KEY_EMULATION_MODE)) {
-            context.withJvmArguments(String.format("-D%s=true", KEY_EMULATION_MODE)); //$NON-NLS-1$
-        }
     }
 
     private File resolveScript(SubMonitor monitor) throws CoreException {

--- a/com.asakusafw.shafu.asakusafw/src/com/asakusafw/shafu/internal/asakusafw/preferences/Messages.java
+++ b/com.asakusafw.shafu.asakusafw/src/com/asakusafw/shafu/internal/asakusafw/preferences/Messages.java
@@ -24,7 +24,6 @@ final class Messages extends NLS {
     public static String ShafuAsakusaPreferencePage_groupSettingsView;
     public static String ShafuAsakusaPreferencePage_itemAsakusaHome;
     public static String ShafuAsakusaPreferencePage_itemCatalogUrl;
-    public static String ShafuAsakusaPreferencePage_itemEmulationMode;
     public static String ShafuAsakusaPreferencePage_itemHadoopCommand;
     public static String ShafuAsakusaPreferencePage_valuePathNotAvailable;
     static {

--- a/com.asakusafw.shafu.asakusafw/src/com/asakusafw/shafu/internal/asakusafw/preferences/ShafuAsakusaPreferenceConstants.java
+++ b/com.asakusafw.shafu.asakusafw/src/com/asakusafw/shafu/internal/asakusafw/preferences/ShafuAsakusaPreferenceConstants.java
@@ -18,7 +18,7 @@ package com.asakusafw.shafu.internal.asakusafw.preferences;
 /**
  * Preference constants of Shafu Asakusa Plug-in.
  * @since 0.1.0
- * @version 0.4.0
+ * @version 0.5.3
  */
 public final class ShafuAsakusaPreferenceConstants {
 
@@ -36,18 +36,6 @@ public final class ShafuAsakusaPreferenceConstants {
      * The default value of catalog URL.
      */
     public static final String DEFAULT_CATALOG_URL = URL_DOWNLOAD_SITE + "template-catalog-release.txt"; //$NON-NLS-1$
-
-    /**
-     * The preference key of whether emulation mode is enabled or not.
-     * @since 0.4.0
-     */
-    public static final String KEY_EMULATION_MODE = "emulationMode"; //$NON-NLS-1$
-
-    /**
-     * The default value of whether emulation mode is enabled or not.
-     * @since 0.4.0
-     */
-    public static final boolean DEFAULT_EMULATION_MODE = false;
 
     private ShafuAsakusaPreferenceConstants() {
         return;

--- a/com.asakusafw.shafu.asakusafw/src/com/asakusafw/shafu/internal/asakusafw/preferences/ShafuAsakusaPreferencePage.java
+++ b/com.asakusafw.shafu.asakusafw/src/com/asakusafw/shafu/internal/asakusafw/preferences/ShafuAsakusaPreferencePage.java
@@ -26,10 +26,7 @@ import org.eclipse.jface.layout.GridDataFactory;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
-import org.eclipse.swt.events.SelectionAdapter;
-import org.eclipse.swt.events.SelectionEvent;
 import org.eclipse.swt.layout.GridLayout;
-import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
@@ -42,7 +39,6 @@ import org.eclipse.ui.IWorkbenchPreferencePage;
 
 import com.asakusafw.shafu.internal.asakusafw.Activator;
 import com.asakusafw.shafu.internal.asakusafw.util.AsakusaFrameworkInfo;
-import com.asakusafw.shafu.ui.fields.BasicField;
 import com.asakusafw.shafu.ui.fields.FieldPreferencePage;
 import com.asakusafw.shafu.ui.fields.PreferenceField;
 
@@ -65,7 +61,6 @@ public class ShafuAsakusaPreferencePage extends FieldPreferencePage implements I
         pane.setLayout(layout);
 
         createUrlField(pane, KEY_CATALOG_URL, 1, Messages.ShafuAsakusaPreferencePage_itemCatalogUrl);
-        createExtensionGroup(pane);
         createSettingsView(pane);
 
         return pane;
@@ -118,44 +113,6 @@ public class ShafuAsakusaPreferencePage extends FieldPreferencePage implements I
                             title,
                             value));
                 }
-            }
-        });
-    }
-
-    private void createExtensionGroup(Composite parent) {
-        Group group = new Group(parent, SWT.NONE);
-        group.setText(Messages.ShafuAsakusaPreferencePage_groupExtensionSettings);
-        group.setLayoutData(GridDataFactory.swtDefaults()
-                .align(SWT.FILL, SWT.BEGINNING)
-                .indent(0, convertHeightInCharsToPixels(1) / 2)
-                .grab(true, false)
-                .create());
-
-        group.setLayout(new GridLayout(1, false));
-        createCheckboxField(group, KEY_EMULATION_MODE, 1, Messages.ShafuAsakusaPreferencePage_itemEmulationMode);
-    }
-
-    private void createCheckboxField(Composite parent, final String key, int span, final String title) {
-        final Button button = new Button(parent, SWT.CHECK);
-        button.setText(title);
-        button.setLayoutData(GridDataFactory.swtDefaults()
-                .span(span, 1)
-                .align(SWT.FILL, SWT.CENTER)
-                .grab(true, false)
-                .indent(BasicField.getDecorationWidth(), 0)
-                .create());
-        registerField(new PreferenceField(key, button) {
-            @Override
-            public void refresh() {
-                String current = getPreferenceValue(key);
-                boolean value = current.equals("true"); //$NON-NLS-1$
-                button.setSelection(value);
-            }
-        });
-        button.addSelectionListener(new SelectionAdapter() {
-            @Override
-            public void widgetSelected(SelectionEvent e) {
-                setPreferenceValue(key, String.valueOf(button.getSelection()));
             }
         });
     }

--- a/com.asakusafw.shafu.asakusafw/src/com/asakusafw/shafu/internal/asakusafw/preferences/ShafuAsakusaPreferencesInitializer.java
+++ b/com.asakusafw.shafu.asakusafw/src/com/asakusafw/shafu/internal/asakusafw/preferences/ShafuAsakusaPreferencesInitializer.java
@@ -33,6 +33,5 @@ public class ShafuAsakusaPreferencesInitializer extends AbstractPreferenceInitia
         LogUtil.debug("Initializing Preferences"); //$NON-NLS-1$
         IPreferenceStore prefs = Activator.getDefault().getPreferenceStore();
         prefs.setDefault(KEY_CATALOG_URL, DEFAULT_CATALOG_URL);
-        prefs.setDefault(KEY_EMULATION_MODE, DEFAULT_EMULATION_MODE);
     }
 }

--- a/com.asakusafw.shafu.asakusafw/src/com/asakusafw/shafu/internal/asakusafw/preferences/messages.properties
+++ b/com.asakusafw.shafu.asakusafw/src/com/asakusafw/shafu/internal/asakusafw/preferences/messages.properties
@@ -3,6 +3,5 @@ ShafuAsakusaPreferencePage_groupExtensionSettings=Extension Features
 ShafuAsakusaPreferencePage_groupSettingsView=Current Settings (Read Only)
 ShafuAsakusaPreferencePage_itemAsakusaHome=Framework Installation Path (ASAKUSA_HOME)
 ShafuAsakusaPreferencePage_itemCatalogUrl=Project Template Catalog URL
-ShafuAsakusaPreferencePage_itemEmulationMode=Enable emulation mode in testing (must be >= 0.7.2)
 ShafuAsakusaPreferencePage_itemHadoopCommand=Hadoop Command Path
 ShafuAsakusaPreferencePage_valuePathNotAvailable=Not Available

--- a/com.asakusafw.shafu.asakusafw/src/com/asakusafw/shafu/internal/asakusafw/preferences/messages_ja.properties
+++ b/com.asakusafw.shafu.asakusafw/src/com/asakusafw/shafu/internal/asakusafw/preferences/messages_ja.properties
@@ -3,6 +3,5 @@ ShafuAsakusaPreferencePage_groupExtensionSettings=\u62e1\u5f35\u6a5f\u80fd
 ShafuAsakusaPreferencePage_groupSettingsView=\u73fe\u5728\u306e\u8a2d\u5b9a (\u5909\u66f4\u4e0d\u53ef)
 ShafuAsakusaPreferencePage_itemAsakusaHome=\u30d5\u30ec\u30fc\u30e0\u30ef\u30fc\u30af\u306e\u30a4\u30f3\u30b9\u30c8\u30fc\u30eb\u5148 (ASAKUSA_HOME)
 ShafuAsakusaPreferencePage_itemCatalogUrl=\u30d7\u30ed\u30b8\u30a7\u30af\u30c8\u30c6\u30f3\u30d7\u30ec\u30fc\u30c8\u30ab\u30bf\u30ed\u30b0URL
-ShafuAsakusaPreferencePage_itemEmulationMode=\u30c6\u30b9\u30c8\u6642\u306b\u30a8\u30df\u30e5\u30ec\u30fc\u30b7\u30e7\u30f3\u30e2\u30fc\u30c9\u3092\u6709\u52b9\u306b\u3059\u308b (0.7.2\u4ee5\u964d\u304c\u5fc5\u8981)
 ShafuAsakusaPreferencePage_itemHadoopCommand=Hadoop\u30b3\u30de\u30f3\u30c9\u306e\u5834\u6240
 ShafuAsakusaPreferencePage_valuePathNotAvailable=\u672a\u8a2d\u5b9a


### PR DESCRIPTION
## Summary

This PR removes "enable emulation mode" settings from the Shafu preferences page.

## Background, Problem or Goal of the patch

Asakusa Framework has been introduced selecting test-kit mechanism since `0.9.0`. It makes the emulation mode settings become unnecessary.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.