### PR TITLE
Set "ignore optional compile problems" for generated sources.

### DIFF
--- a/com.asakusafw.shafu.asakusafw/scripts/init.gradle
+++ b/com.asakusafw.shafu.asakusafw/scripts/init.gradle
@@ -30,31 +30,33 @@ allprojects { Project project ->
             def conv = project.asakusafw
             def modelgenSrc = project.relativePath(conv.modelgen.modelgenSourceDirectory ?: '').replace('\\', '/')
             def annotationSrc = project.relativePath(conv.javac.annotationSourceDirectory ?: '').replace('\\', '/')
+            def putAttribute = { attrs, name, value ->
+                attrs.collect {
+                    it.children().find { it.name() == 'attribute' && it.@name == name } ?: it.appendNode('attribute', [name: name])
+                }.each {
+                    it.@value = value
+                }
+            }
             project.eclipse.classpath {
                 file.withXml { provider ->
-                    provider.asNode().children().findAll{
+                    def genSrcAttributes = provider.asNode().children().findAll{
                         it.name() == 'classpathentry' \
                         && it.@kind == 'src' \
                         && it.@path \
                         && ( it.@path == modelgenSrc || it.@path == annotationSrc )
                     }.collect {
                         it.children().find { it.name() == 'attributes' } ?: it.appendNode('attributes')
-                    }.collect {
-                        it.children().find { it.name() == 'attribute' && it.@name == 'optional' } ?: it.appendNode('attribute', [name: 'optional'])
-                    }.each {
-                        it.@value = 'true'
                     }
-                    provider.asNode().children().findAll{
+                    def libAttributes = provider.asNode().children().findAll{
                         it.name() == 'classpathentry' \
                         && it.@kind == 'lib' \
                         && it.@path
                     }.collect {
                         it.children().find { it.name() == 'attributes' } ?: it.appendNode('attributes')
-                    }.collect {
-                        it.children().find { it.name() == 'attribute' && it.@name == 'source_encoding' } ?: it.appendNode('attribute', [name: 'source_encoding'])
-                    }.each {
-                        it.@value = 'UTF-8'
                     }
+                    putAttribute(genSrcAttributes, 'optional', 'true')
+                    putAttribute(genSrcAttributes, 'ignore_optional_problems', 'true')
+                    putAttribute(libAttributes, 'source_encoding', 'UTF-8')
                 }
             }
         }


### PR DESCRIPTION
## Summary

This PR enables an Eclipse setting "ignore optional compile problems" for generated sources. It suppresses unavoidable diagnostic messages on the data model classes and operator factory/implementation classes.

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

This introduces an attribute `ignore_optional_problems=true` into `.classpath` file:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<classpath>
  ...
  <classpathentry kind="src" path="build/generated-sources/modelgen">
    <attributes>
      <attribute name="optional" value="true"/>
      <attribute name="ignore_optional_problems" value="true"/>
    </attributes>
  </classpathentry>
  <classpathentry kind="src" path="build/generated-sources/annotations">
    <attributes>
      <attribute name="optional" value="true"/>
      <attribute name="ignore_optional_problems" value="true"/>
    </attributes>
  </classpathentry>
  ...
```

Its attribute has been introduced since Eclipse 3.8.

## Related Issue, Pull Request or Code

N/A.
