### PR TITLE
Don't use `org.gradle.util` package in init scripts.

### DIFF
--- a/com.asakusafw.shafu.asakusafw/scripts/init.gradle
+++ b/com.asakusafw.shafu.asakusafw/scripts/init.gradle
@@ -7,7 +7,7 @@ allprojects { Project project ->
             once.call()
             once = {}
         }
-        if (GradleVersion.current() >= GradleVersion.version('2.0')) {
+        if (project.plugins.respondsTo("withId")) {
             project.plugins.withId('asakusafw') {
                 cl.call()
             }


### PR DESCRIPTION
## Summary

This PR removes use of classes in `org.gradle.util` in init scripts.

## Background, Problem or Goal of the patch

`org.gradle.util.GradleVersion` has been deprecated since Gradle 4.3 and will be removed in 5.0.

## Design of the fix, or a new feature

This replaced using `GradleVersion` with `Object.respondTo` to check whether the target feature is enabled or not. It will return an empty list if the target method is not available.

## Related Issue, Pull Request or Code

N/A.