### PR TITLE
Bump up default Gradle version to 4.3.1

### DIFF
--- a/com.asakusafw.shafu.ui/src/com/asakusafw/shafu/internal/ui/preferences/ShafuPreferenceConstants.java
+++ b/com.asakusafw.shafu.ui/src/com/asakusafw/shafu/internal/ui/preferences/ShafuPreferenceConstants.java
@@ -144,7 +144,7 @@ public final class ShafuPreferenceConstants {
      * The Gradle version default value ({@value}).
      * @since 0.2.7
      */
-    public static final String DEFAULT_GRADLE_VERSION = "3.1"; //$NON-NLS-1$
+    public static final String DEFAULT_GRADLE_VERSION = "4.3.1"; //$NON-NLS-1$
 
     /**
      * The default value of {@link #KEY_USE_HTTPS}.


### PR DESCRIPTION
## Summary
This PR bump up default Gradle version to 4.3.1 ( this is the default Gradle version of Asakusa 0.10.0 ).

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
