### PR TITLE
Replace maven repository url that use http with https

### DIFF
--- a/com.asakusafw.shafu.asakusafw/scripts/init.gradle
+++ b/com.asakusafw.shafu.asakusafw/scripts/init.gradle
@@ -94,4 +94,18 @@ allprojects { Project project ->
             }
         }
     }
+
+    // replace maven repository url that use http with https
+    def targetHosts = [
+        'repo1.maven.org',
+        'repo.maven.apache.org',
+        'asakusafw.s3.amazonaws.com'
+    ]
+    project.repositories.withType(MavenArtifactRepository) { repository ->
+        if ( repository.url.scheme == 'http' && targetHosts.contains(repository.url.host) ) {
+            URI newUrl = new URI("https", repository.url.authority, repository.url.path, repository.url.query, repository.url.fragment)
+            logger.info("Replace repository url: ${repository.url} -> ${newUrl}")
+            repository.url = newUrl
+        }
+    }
 }


### PR DESCRIPTION
## Summary
This PR adds init script featrure to replace maven repository url that use http with https in Gradle projects.

## Background, Problem or Goal of the patch
Effective January 15, 2020, The Maven Central Repository no longer supports insecure communication over plain HTTP and requires that all requests to the repository are encrypted over HTTPS.

See detail:
https://support.sonatype.com/hc/en-us/articles/360041287334

## Design of the fix, or a new feature
Automatically convert URLs including http to https via Shafu.

## Related Issue, Pull Request or Code
N/A