### PR TITLE
Bump the default Gradle version to `4.7`.

### DIFF
--- a/com.asakusafw.shafu.ui/src/com/asakusafw/shafu/internal/ui/preferences/ShafuPreferenceConstants.java
+++ b/com.asakusafw.shafu.ui/src/com/asakusafw/shafu/internal/ui/preferences/ShafuPreferenceConstants.java
@@ -156,7 +156,7 @@ public final class ShafuPreferenceConstants {
      * The Gradle version default value ({@value}).
      * @since 0.2.7
      */
-    public static final String DEFAULT_GRADLE_VERSION = "4.3.1"; //$NON-NLS-1$
+    public static final String DEFAULT_GRADLE_VERSION = "4.7"; //$NON-NLS-1$
 
     /**
      * The default value of {@link #KEY_USE_HTTPS}.


### PR DESCRIPTION
## Summary

This PR bumps the default Gradle version `4.3.1` to `4.7`.

## Background, Problem or Goal of the patch

Gradle `< 4.7` does not support tooling API with Java `>= 11`.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.
